### PR TITLE
Revert commit 6099c31: Fix video render slow issue

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -316,7 +316,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
     IJKLog(@"%s", __FUNCTION__);
 //    [self unregisterApplicationObservers];
     //ijkmp_global_set_inject_callback(NULL);
-    [_glView invalidate];
 }
 
 - (void)setShouldAutoplay:(BOOL)shouldAutoplay
@@ -369,8 +368,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 {
     if (!_mediaPlayer)
         return;
-    
-    [_glView monitorDisplay:nil];
 
     [self setScreenOn:_keepScreenOnWhilePlaying];
 
@@ -396,8 +393,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
     [self stopHudTimer];
     ijkmp_stop(_mediaPlayer);
-    
-    [_glView monitorDisplay:nil];
     
     if (self.shouldLogStream) {
         NSTimeInterval end = [NSDate date].timeIntervalSince1970;
@@ -538,7 +533,6 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
     [self stopHudTimer];
     [self unregisterApplicationObservers];
     [self setScreenOn:NO];
-    [_glView monitorDisplay:nil];
 
     [self performSelectorInBackground:@selector(shutdownWaitStop:) withObject:self];
 }
@@ -1245,11 +1239,6 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
             [[NSNotificationCenter defaultCenter]
              postNotificationName:IJKMPMoviePlayerFirstVideoFrameRenderedNotification
              object:self];
-#pragma mark - E7
-            [_glView monitorDisplay:^(BOOL displaying) {
-                [[NSNotificationCenter defaultCenter] postNotificationName:displaying ? IJKMPMoviePlayerVideoFrameRenderResumedNotification : IJKMPMoviePlayerVideoFrameRenderStoppedNotification object:self];
-            }];
-#pragma mark -
             break;
         }
         case FFP_MSG_AUDIO_RENDERING_START: {

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -149,9 +149,6 @@ IJK_EXTERN NSString *const IJKMPMoviePlayerVideoDecoderOpenNotification;
 IJK_EXTERN NSString *const IJKMPMoviePlayerFirstVideoFrameRenderedNotification;
 IJK_EXTERN NSString *const IJKMPMoviePlayerFirstAudioFrameRenderedNotification;
 
-IJK_EXTERN NSString *const IJKMPMoviePlayerVideoFrameRenderStoppedNotification;
-IJK_EXTERN NSString *const IJKMPMoviePlayerVideoFrameRenderResumedNotification;
-
 IJK_EXTERN NSString *const IJKMPMoviePlayerDidSeekCompleteNotification;
 IJK_EXTERN NSString *const IJKMPMoviePlayerDidSeekCompleteTargetKey;
 IJK_EXTERN NSString *const IJKMPMoviePlayerDidSeekCompleteErrorKey;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
@@ -40,9 +40,6 @@ NSString *const IJKMPMoviePlayerVideoDecoderOpenNotification = @"IJKMPMoviePlaye
 NSString *const IJKMPMoviePlayerFirstVideoFrameRenderedNotification = @"IJKMPMoviePlayerFirstVideoFrameRenderedNotification";
 NSString *const IJKMPMoviePlayerFirstAudioFrameRenderedNotification = @"IJKMPMoviePlayerFirstAudioFrameRenderedNotification";
 
-NSString *const IJKMPMoviePlayerVideoFrameRenderStoppedNotification = @"IJKMPMoviePlayerVideoFrameRenderStoppedNotification";
-NSString *const IJKMPMoviePlayerVideoFrameRenderResumedNotification = @"IJKMPMoviePlayerVideoFrameRenderResumedNotification";
-
 NSString *const IJKMPMoviePlayerAccurateSeekCompleteNotification = @"IJKMPMoviePlayerAccurateSeekCompleteNotification";
 
 NSString *const IJKMPMoviePlayerDidSeekCompleteNotification = @"IJKMPMoviePlayerDidSeekCompleteNotification";

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
@@ -44,12 +44,6 @@
 
 @property (nonatomic) int rotationDegrees;
 
-- (void)invalidate;
-
-/**
- * Start monitoring after first frame displayed.
- */
-- (void)monitorDisplay:(void(^)(BOOL displaying))monitorCallback;
 #pragma mark -
 
 @end


### PR DESCRIPTION
[why] Notifications "IJKMPMoviePlayerVideoFrameRenderStoppedNotification" and "IJKMPMoviePlayerVideoFrameRenderResumedNotification" are not used anymore. For saving battery usage.
[how] Rollback commit 6099c31.