### PR TITLE
[APP-18477] Fix video freeze issue when occurs decode error -12909

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffinc.h
+++ b/ijkmedia/ijkplayer/ff_ffinc.h
@@ -42,6 +42,7 @@
 #include "ijksdl/ijksdl.h"
 
 typedef int (*ijk_inject_callback)(void *opaque, int type, void *data, size_t data_size);
+typedef void (*ijk_decode_error_callback)(void *opaque, int error_code);
 
 #define FFP_OPT_CATEGORY_FORMAT 1
 #define FFP_OPT_CATEGORY_CODEC  2

--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -3695,6 +3695,19 @@ void ffp_global_set_inject_callback(ijk_inject_callback cb)
 {
     s_inject_callback = cb;
 }
+            
+static ijk_decode_error_callback s_decode_error_callback;
+void ffp_decode_error_callback(void *opaque, int error_code)
+{
+    if (s_decode_error_callback)
+        s_decode_error_callback(opaque, error_code);
+    return;
+}
+
+void ffp_global_set_decode_error_callback(ijk_decode_error_callback cb)
+{
+    s_decode_error_callback = cb;
+}
 
 void ffp_io_stat_register(void (*cb)(const char *url, int type, int bytes))
 {

--- a/ijkmedia/ijkplayer/ff_ffplay.h
+++ b/ijkmedia/ijkplayer/ff_ffplay.h
@@ -34,6 +34,8 @@ void      ffp_global_uninit();
 void      ffp_global_set_log_report(int use_report);
 void      ffp_global_set_log_level(int log_level);
 void      ffp_global_set_inject_callback(ijk_inject_callback cb);
+void      ffp_global_set_decode_error_callback(ijk_decode_error_callback cb);
+void      ffp_decode_error_callback(void *opaque, int error_code);
 void      ffp_io_stat_register(void (*cb)(const char *url, int type, int bytes));
 void      ffp_io_stat_complete_register(void (*cb)(const char *url,
                                                    int64_t read_bytes, int64_t total_size,

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -736,6 +736,8 @@ typedef struct FFPlayer {
     int64_t log_last_pts;
     int log_duration;
     int log_bytes_size;
+    
+    bool did_call_handle_decode_error;
 } FFPlayer;
 
 #define fftime_to_milliseconds(ts) (av_rescale(ts, 1000, AV_TIME_BASE))
@@ -862,6 +864,8 @@ inline static void ffp_reset_internal(FFPlayer *ffp)
     ffp->ijkio_inject_opaque = NULL;
     ffp_reset_statistic(&ffp->stat);
     ffp_reset_demux_cache_control(&ffp->dcc);
+    
+    ffp->did_call_handle_decode_error = false;
 }
 
 inline static void ffp_notify_msg1(FFPlayer *ffp, int what) {

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -737,7 +737,7 @@ typedef struct FFPlayer {
     int log_duration;
     int log_bytes_size;
     
-    bool did_call_handle_decode_error;
+    bool is_handling_error;
 } FFPlayer;
 
 #define fftime_to_milliseconds(ts) (av_rescale(ts, 1000, AV_TIME_BASE))
@@ -865,7 +865,7 @@ inline static void ffp_reset_internal(FFPlayer *ffp)
     ffp_reset_statistic(&ffp->stat);
     ffp_reset_demux_cache_control(&ffp->dcc);
     
-    ffp->did_call_handle_decode_error = false;
+    ffp->is_handling_error = false;
 }
 
 inline static void ffp_notify_msg1(FFPlayer *ffp, int what) {

--- a/ijkmedia/ijkplayer/ijkplayer.c
+++ b/ijkmedia/ijkplayer/ijkplayer.c
@@ -91,6 +91,11 @@ void ijkmp_global_set_inject_callback(ijk_inject_callback cb)
     ffp_global_set_inject_callback(cb);
 }
 
+void ijkmp_global_set_decode_error_callback(ijk_decode_error_callback cb)
+{
+    ffp_global_set_decode_error_callback(cb);
+}
+
 const char *ijkmp_version()
 {
     return IJKPLAYER_VERSION;

--- a/ijkmedia/ijkplayer/ijkplayer.h
+++ b/ijkmedia/ijkplayer/ijkplayer.h
@@ -156,6 +156,7 @@ void            ijkmp_global_uninit();
 void            ijkmp_global_set_log_report(int use_report);
 void            ijkmp_global_set_log_level(int log_level);   // log_level = AV_LOG_xxx
 void            ijkmp_global_set_inject_callback(ijk_inject_callback cb);
+void            ijkmp_global_set_decode_error_callback(ijk_decode_error_callback cb);
 const char     *ijkmp_version();
 void            ijkmp_io_stat_register(void (*cb)(const char *url, int type, int bytes));
 void            ijkmp_io_stat_complete_register(void (*cb)(const char *url,

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -133,6 +133,7 @@ typedef enum IJKLogLevel {
 @property (nonatomic, retain) id<IJKMediaUrlOpenDelegate> liveOpenDelegate;
 
 @property (nonatomic, retain) id<IJKMediaNativeInvokeDelegate> nativeInvokeDelegate;
+@property (nonatomic, retain) id<IJKDecodeErrorHandleDelegate> decodeErrorDelegate;
 
 - (void)didShutdown;
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -32,6 +32,7 @@
 #import "NSString+IJKMedia.h"
 #import "ijkioapplication.h"
 #include "string.h"
+#import "IJKVideoToolBoxSync.h"
 
 // 17media
 #import "IJKLog.h"
@@ -209,6 +210,7 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
         if (self) {
             ijkmp_global_init();
             ijkmp_global_set_inject_callback(ijkff_inject_callback);
+            ijkmp_global_set_decode_error_callback(ijkff_decode_error_callback);
 
             [IJKFFMoviePlayerController checkIfFFmpegVersionMatch:NO];
 
@@ -1617,6 +1619,19 @@ static int ijkff_inject_callback(void *opaque, int message, void *data, size_t d
         default: {
             return 0;
         }
+    }
+}
+
+static void ijkff_decode_error_callback(void *opaque, int error_code)
+{
+    IJKWeakHolder *weakHolder = (__bridge IJKWeakHolder*)opaque;
+    IJKFFMoviePlayerController *mpc = weakHolder.object;
+    
+    if (!mpc)
+        return;
+    
+    if ([mpc.decodeErrorDelegate respondsToSelector:@selector(handleDecodeError:)]) {
+        [mpc.decodeErrorDelegate handleDecodeError:error_code];
     }
 }
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -222,3 +222,9 @@ typedef NS_ENUM(NSInteger, IJKMediaEvent) {
 - (int)invoke:(IJKMediaEvent)event attributes:(NSDictionary *)attributes;
 
 @end
+
+@protocol IJKDecodeErrorHandleDelegate <NSObject>
+
+- (void)handleDecodeError:(int)errorCode;
+
+@end


### PR DESCRIPTION
## Why

Sometimes, while video resolution changing, the video would be freezing

## How

WORKAROUND - When it occurs decode error, using a delegate to notify the app to reset the player

## Risk

Medium

## Influence scope

`ff_ffinc.h`
`ff_ffplay.h`
`ff_ffplay.c`
`ff_ffplay_def.h`
`ijkplayer.h`
`ijkplayer.c`
`IJKFFMoviePlayerController.h`
`IJKFFMoviePlayerController.m`
`IJKMediaPlayback.h`
`IJKVideoToolBoxSync.m`

## JIRA

[[APP-18477] Fix video freeze issue when video resolution was changed](https://17media.atlassian.net/browse/APP-18477)