### PR TITLE
[APP-20359][iOS][Crash] renderer.c line 182

### DIFF
--- a/ijkmedia/ijksdl/gles2/renderer.c
+++ b/ijkmedia/ijksdl/gles2/renderer.c
@@ -178,8 +178,9 @@ IJK_GLES2_Renderer *IJK_GLES2_Renderer_create(SDL_VoutOverlay *overlay)
             ALOGE("[GLES2] unknown format %4s(%d)\n", (char *)&overlay->format, overlay->format);
             return NULL;
     }
-
-    renderer->format = overlay->format;
+    if (renderer != NULL) {
+        renderer->format = overlay->format;
+    }
     return renderer;
 }
 


### PR DESCRIPTION
## Why
<!--- Request / Improvement / Root cause -->
[Firebase crashlytics](https://console.firebase.google.com/u/0/project/media17-prod/crashlytics/app/ios:com.machipopo.story17/issues/5a3a9c0d8cb3c2fa634ece11?time=last-seven-days&sessionEventKey=3929341e7f4c40d8b3af476a2df6c781_1570487597624444362)
App crash when ijkplayer create renderer
Guessed that it is because access to an null object

## How
<!--- What you did -->
Add judgement to avoid access null object

## Risk
<!--- Risk level（high/medium/low） -->
medium

## Influence scope
<!--- Changed files / Related functions -->
Changed files:
`renderer.c`

## JIRA
<!--- [APP-XXXX] JIRA issue title -->
[[APP-20359][iOS][Crash] renderer.c line 182](https://17media.atlassian.net/browse/APP-20359)