### PR TITLE
[APP-24567] Fix video freeze problem when app enter background (m3u8 stream)

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
@@ -830,6 +830,8 @@ static int decode_video(Ijk_VideoToolBox_Opaque* context, AVCodecContext *avctx,
     
     if (ff_avpacket_is_idr(avpkt) == true) {
         context->idr_based_identified = true;
+    } else {
+        context->idr_based_identified = false;
     }
     if (ff_avpacket_i_or_idr(avpkt, context->idr_based_identified) == true) {
         ResetPktBuffer(context);

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
@@ -791,6 +791,9 @@ static int decode_video(Ijk_VideoToolBox_Opaque* context, AVCodecContext *avctx,
     
     if (ff_avpacket_is_idr(avpkt) == true) {
         context->idr_based_identified = true;
+    } else {
+        // Add it to correctly identify keyframe is I-frame or IDR-frame
+        context->idr_based_identified = false;
     }
     if (ff_avpacket_i_or_idr(avpkt, context->idr_based_identified) == true) {
         ResetPktBuffer(context);


### PR DESCRIPTION
## Why
<!--- Request / Improvement / Root cause -->
Use wrong way to determine the frame is key-frame or not

## How
<!--- What you did -->
Correct the flag state to use the right way determine key-frame

## Risk
<!--- Risk level（high/medium/low） -->
medium

## Influence scope
<!--- Changed files / Related functions -->
`IJKVideoToolBoxSync.m`

## JIRA
<!--- [APP-XXXX] JIRA issue title -->
[[APP-24567][iOS] 進入concert room後跳回手機主畫面再跳回concert room畫面會卡住](https://17media.atlassian.net/browse/APP-24567)